### PR TITLE
fix: the @dopt/please* family of packages specify a prettier.config.mjs

### DIFF
--- a/.changeset/famous-cooks-raise.md
+++ b/.changeset/famous-cooks-raise.md
@@ -1,0 +1,7 @@
+---
+"@dopt/please-function": patch
+"@dopt/please-parser": patch
+"@dopt/please": patch
+---
+
+Ensure format on save in editor in this repository follows the rules of the package.

--- a/packages/@dopt/please-function/prettier.config.mjs
+++ b/packages/@dopt/please-function/prettier.config.mjs
@@ -1,0 +1,2 @@
+import pkgToolsConfig from './pkg-tools.config';
+return pkgToolsConfig.format;

--- a/packages/@dopt/please-function/tsconfig.json
+++ b/packages/@dopt/please-function/tsconfig.json
@@ -7,6 +7,6 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "exclude": ["node_modules", "dist", "build.config.ts"],
+  "exclude": ["node_modules", "dist"],
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/@dopt/please-parser/generate-parser.cjs
+++ b/packages/@dopt/please-parser/generate-parser.cjs
@@ -1,10 +1,10 @@
-var fs = require('fs');
-var peggy = require('peggy');
-var tspegjs = require('ts-pegjs');
+const fs = require('fs');
+const peggy = require('peggy');
+const tspegjs = require('ts-pegjs');
 
 fs.readFile('src/parser.pegjs', function (err, data) {
   if (err) throw err;
-  var parser = peggy.generate(data.toString(), {
+  const parser = peggy.generate(data.toString(), {
     output: 'source',
     // Helps in debugging
     // trace: true,

--- a/packages/@dopt/please-parser/prettier.config.mjs
+++ b/packages/@dopt/please-parser/prettier.config.mjs
@@ -1,0 +1,2 @@
+import pkgToolsConfig from './pkg-tools.config';
+return pkgToolsConfig.format;

--- a/packages/@dopt/please/prettier.config.mjs
+++ b/packages/@dopt/please/prettier.config.mjs
@@ -1,0 +1,2 @@
+import pkgToolsConfig from './pkg-tools.config';
+return pkgToolsConfig.format;


### PR DESCRIPTION
Fixes https://github.com/pkg-tools/pkg-tools/issues/26 in this repo, which was introduced with https://github.com/dopt/please/commit/734c8f5d860c8baad2d8a871af3402cddc90eebb